### PR TITLE
change EY link to use wayback machine link

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Add the following to your gemfile
 Uptime Monitoring
 =================
 
-See EngineYard's support guide on [uptime monitoring for your rails application](http://www.engineyard.com/support/guides/uptime_monitoring_for_your_rails_application)
+See EngineYard's support guide on [uptime monitoring for your rails application](https://web.archive.org/web/20090222170354/http://www.engineyard.com/support/guides/uptime_monitoring_for_your_rails_application)
 
 Monit
 =====


### PR DESCRIPTION
Noticed the link was a 404. I couldn't find where the page moved on EY, so changed to an internet archive link. 

The original content does use `fitter-happier`, so I thought that would be better than deleting the link entirely. 